### PR TITLE
Feature implementation from commits 74a8301..782b71e

### DIFF
--- a/doc/_docstrings/catplot.ipynb
+++ b/doc/_docstrings/catplot.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "sns.catplot(\n",
     "    data=df, x=\"age\", y=\"class\", hue=\"sex\",\n",
-    "    kind=\"violin\", bw=.25, cut=0, split=True,\n",
+    "    kind=\"violin\", bw_adjust=.5, cut=0, split=True,\n",
     ")"
    ]
   },

--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -7,7 +7,10 @@ Citing seaborn
 --------------
 
 If seaborn is integral to a scientific publication, please cite it.
-A paper describing seaborn has been published in the `Journal of Open Source Software <https://joss.theoj.org/papers/10.21105/joss.03021>`_.
+A paper describing seaborn has been published in the `Journal of Open Source Software <https://joss.theoj.org/papers/10.21105/joss.03021>`_:
+
+    Waskom, M. L., (2021). seaborn: statistical data visualization. Journal of Open Source Software, 6(60), 3021, https://doi.org/10.21105/joss.03021.
+
 Here is a ready-made BibTeX entry:
 
 .. highlight:: none

--- a/doc/whatsnew/v0.13.0.rst
+++ b/doc/whatsnew/v0.13.0.rst
@@ -1,16 +1,129 @@
 v0.13.0 (Unreleased)
 --------------------
 
+Major enhancements to categorical plots
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Seaborn's :ref:`categorical functions <categorical_api>` have been completely rewritten for this release. This provided the opportunity to address some longstanding quirks as well as to add a number of smaller but much-desired features and enhancements.
+
+Support for numeric and date-time data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+|Feature|
+
+The categorical functions have historically treated *all* data as categorical, even when it has a numeric or date-time type. This can now be controlled with the new `native_scale` parameter. The default remains `False` to preserve existing behavior. But with `native_scale=True`, values will be treated as they would by other seaborn or matplotlib functions. Element widths will be derived from the minimum distance between two unique values on the categorical axis.
+
+Additionally, while seaborn previously determined the mapping from categorical values to ordinal positions internally, it is now delegated to matplotlib. This should mostly be transparent to the user, but categorical plots (even with `native_scale=False`) will better align with artists added by other seaborn or matplotlib functions in most cases, and matplotlib's interactive machinery will work better.
+
+Changes to color defaults and specification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+|API| |Defaults|
+
+The categorical functions now act more like the rest of seaborn in that they will produce a plot with a single main color unless the `hue` variable is assigned. Previously, there would be an implicit redundant color mapping (e.g., each box in a boxplot would get a separate color from the default palette). To retain the previous behavior, explicitly assign a redundant `hue` variable (e.g., `boxplot(data, x="x", y="y", hue="x")`).
+
+Two related idiosyncratic color specifications are deprecated, but they will continue to work (with a warning) for one release cycle:
+
+- Passing a `palette` without explicitly assigning `hue` is no longer supported (add an explicitly redundant `hue` assignment instead).
+
+- Passing a `color` while assigning `hue` to produce a gradient is no longer supported (use `palette="dark:{color}"` or `palette="light:{color}"` instead).
+
+Finally, like other seaborn functions, the default palette now depends on the variable type, and a sequential palette will be used with numeric data. To retain the previous behavior, pass the name of a qualitative palette (e.g., `palette="deep"` for seaborn's default). Accordingly, the functions have gained a parameter to control numeric color mappings (`hue_norm`).
+
+Other features, enhancements, and changes to categorical plots
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following updates apply to multiple categorical functions.
+
+- |Feature| All functions now accept a `legend` parameter, which can be a boolean (to suppress the legend) or one of `{"auto", "brief"`, `"full"}` to control the amount of information shown in the legend for a numerical color mapping.
+
+- |Feature| All functions now accept a callable `formatter` parameter to control the string representation of the data.
+
+- |Feature| All functions that draw a solid patch now accept a boolean `fill` parameter, which when set to `False` will draw line-art elements.
+
+- |Feature| All functions that support dodging now have an additional `gap` parameter that can be set to a non-zero value to leave space between dodged elements.
+
+- |Feature| The :func:`boxplot`, :func:`boxenplot`, and :func:`violinplot` functions now support a single `linecolor` parameter.
+
+- |Enhancement| The default value for `dodge` has changed from `True` to `"auto"`. With `"auto"`, elements will dodge only when at least one set of elements would otherwise overlap.
+
+- |Enhancement| When the value axis of the plot has a non-linear scale, the statistical operations (e.g. an aggregation in :func:`pointplot` or the kernel density fit in :func:`violinplot`) are now applied in that scale space.
+
+- |Enhancement| All functions now accept a `log_scale` parameter. With a single argument, this will set the scale on the "value" axis (*opposite* the categorical axis). A tuple will set each axis directly (although setting a log scale categorical axis also requires `native_scale=True`).
+
+- |Enhancement| The `orient` parameter now accepts `"x"/"y"` to specify the categorical axis, matching the objects interface.
+
+- |Enhancement| The categorical functions are generally more deferential to the user's additional matplotlib keyword arguments.
+
+- |API| Using `"gray"` to select an automatic gray value that complements the main palette is now deprecated in favor of `"auto"`.
+
+The following updates are function-specific.
+
+- |API| |Feature| In :func:`pointplot`, a single :class:`matplotlib.lines.Line2D` artist is now used rather than adding separate :class:`matplotlib.collections.PathCollection` artist for the points. As a result, it is now possible to pass additional keyword arguments for complete customization the appearance of both the lines and markers; additionally, the legend representation is improved. Accordingly, parameters that previously allowed only partial customization (`scale`, `join`, and `errwidth`) are now deprecated. The old parameters will now trigger detailed warning messages with instructions for adapting existing code.
+
+- |API| |Feature| The bandwidth specification in :func:`violinplot` better aligns with :func:`kdeplot`, as the `bw` parameter is now deprecated in favor of `bw_method` and `bw_adjust`.
+
+- |API| |Enhancement| In :func:`boxenplot`, the boxen are now drawn with separate patch artists in each tail. This may have consequences for code that works with the underlying artists, but it produces a better result for low-alpha / unfilled plots and enables proper area/density scaling.
+
+- |API| |Enhancement| In :func:`barplot`, the `errcolor`` and `errwidth` parameters are now deprecated in favor of a more general `err_kws`` dictionary. The existing parameters will continue to work for two releases.
+
+- |API| In :func:`violinplot`, the `scale` and `scale_hue` parameters have been renamed to `density_norm` and `common_norm` for clarity and to reflect the fact that common normalization is now applied over both hue and faceting variables in :func:`catplot`.
+
+- |API| In :func:`boxenplot`, the `scale` parameter has been renamed to `width_method` as part of a broader effort to de-confound the meaning of "scale" in seaborn parameters.
+
+- |Defaults| |Enhancement| When passing a vector to the `data` parameter of :func:`barplot` or :func:`pointplot`, a bar or point will be drawn for each entry in the vector rather than plotting a single aggregated value. To retain the previous behavior, assign the vector to the `y` variable.
+
+- |Defaults| |Enhancement| In :func:`boxplot`, the default flier marker now follows the matplotlib rcparams so that it can be globally customized.
+
+- |Defaults| |Enhancement| When using `split=True` and `inner="box"` in :func:`violinplot`, a separate mini-box is now drawn for each split violin.
+
+- |Defaults| |Enhancement| In :func:`boxenplot`, all plots now use a consistent luminance ramp for the different box levels. This leads to a change in the appearance of existing plots, but reduces the chances of a misleading result.
+
+- |Defaults| |Enhancement| The `"area"` scaling in :func:`boxenplot` now approximates the density of the underlying observations, including for asymmetric distributions. This produces a substantial change in the appearance of plots with `width_method="area"`, although the existing behavior was poorly defined.
+
+- |Feature| In :func:`countplot`, the new `stat` parameter can be used to apply a normalization (e.g to show a `"percent"` or `"proportion"`).
+
+- |Feature| The `split` parameter in :func:`violinplot` is now more general and can be set to `True` regardless of the number of `hue` variable levels (or even without `hue`). This is probably most useful for showing half violins.
+
+- |Feature| In :func:`violinplot`, the new `inner_kws` parameter allows additional control over the interior artists.
+
+- |Enhancement| It is no longer required to use a `DataFrame` in :func:`catplot`, as data vectors can now be passed directly.
+
+- |Enhancement| In :func:`boxplot`, the artists that comprise each box plot are now packaged in a `BoxPlotContainer` for easier post-plotting access.
+
+Other changes
+^^^^^^^^^^^^^
+
+- |Feature| Nearly all functions / objects now use the `dataframe exchange protocol <https://data-apis.org/dataframe-protocol/latest/index.html>`_ to accept `DataFrame` objects from libraries other than `pandas` (e.g. `polars`). Note that seaborn will still convert the data object to pandas internally, but this feature will simplify code for users of other dataframe libraries (:pr:`3369`).
+
 - |Feature| Added control over the default theme to :class:`objects.Plot` (:pr:`3223`)
 
 - |Feature| Added control over the default notebook display to :class:`objects.Plot` (:pr:`3225`).
 
+- |Feature| Added the concept of a "layer legend" in :class:`objects.Plot` via the new `label` parameter in :meth:`objects.Plot.add` (:pr:`3456`).
+
+- |Enhancement| Improved the legend display for relational and categorical functions to better represent the user's additional keyword arguments (:pr:`3467`).
+
+- |Enhancement| In :meth:`objects.Plot.scale`, :meth:`objects.Plot.limit`, and :meth:`objects.Plot.label` the `x` / `y` parameters can be used to set a common scale / limit / label for paired subplots (:pr:`3458`).
+
 - |Enhancement| Updated :func:`load_dataset` to use an approach more compatible with `pyiodide` (:pr:`3234`).
 
-- |Fix| Fixed :class:`objects.Bar` and `objects.Bars` widths when using a nonlinear scale (:pr:`3217`).
+- |Enhancement| In :func:`ecdfplot`, `stat="percent"` is now a valid option (:pr:`3336`).
+
+- |Enhancement| Generalized support for performing statistics in the appropriate space based on axes scales; previously support for this was spotty and at best worked only for log scales (:pr:`3440`).
+
+- |API| Support for array-typed palettes is now deprecated. This was no previously documented as supported, but it worked by accident in a few places (:pr:`3452`).
+
+- |Fix| Fixed :class:`objects.Bar` and :class:`objects.Bars` widths when using a nonlinear scale (:pr:`3217`).
+
+- |Fix| Worked around an issue in matplotlib that caused incorrect results in :func:`move_legend` when `labels` were provided (:pr:`3454`).
 
 - |Fix| Fixed a bug introduced in v0.12.0 where :func:`histplot` added a stray empty `BarContainer` (:pr:`3246`).
 
 - |Fix| Fixed a bug where :meth:`objects.Plot.on` would override a figure's layout engine (:pr:`3216`).
 
 - |Fix| Fixed a bug introduced in v0.12.0 where :func:`lineplot` with a list of tuples for the keyword argument dashes caused a TypeError (:pr:`3316`).
+
+- |Fix| Fixed a bug in :class:`PairGrid` that caused an exception when the input dataframe had a column multiindex (:pr:`3407`).
+
+- |Fix| Improved a few edge cases when using pandas nullable dtypes (:pr:`3394`).

--- a/doc/whatsnew/v0.13.0.rst
+++ b/doc/whatsnew/v0.13.0.rst
@@ -1,19 +1,23 @@
 v0.13.0 (Unreleased)
 --------------------
 
+This is a major release with a number of important new features and changes. The highlight is a major overhaul to seaborn's categorical plotting functions, providing them with many new capabilities and better aligning their API with the rest of the library. There is also provisional support for alternate dataframe libraries like `polars <https://www.pola.rs>`_, a new theme and display configuration system for :class:`objects.Plot`, and many smaller bugfixes and enhancements.
+
+Updating is recommended, but users are encouraged to carefully check the outputs of existing code that uses the categorical functions, and they should be aware of some deprecations and intentional changes to the default appearance of the resulting plots (see notes below with |API| and |Defaults| tags).
+
 Major enhancements to categorical plots
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Seaborn's :ref:`categorical functions <categorical_api>` have been completely rewritten for this release. This provided the opportunity to address some longstanding quirks as well as to add a number of smaller but much-desired features and enhancements.
 
-Support for numeric and date-time data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Support for numeric and datetime data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 |Feature|
 
-The categorical functions have historically treated *all* data as categorical, even when it has a numeric or date-time type. This can now be controlled with the new `native_scale` parameter. The default remains `False` to preserve existing behavior. But with `native_scale=True`, values will be treated as they would by other seaborn or matplotlib functions. Element widths will be derived from the minimum distance between two unique values on the categorical axis.
+The categorical functions have historically treated *all* data as categorical, even when it has a numeric or datetime type. This can now be controlled with the new `native_scale` parameter. The default remains `False` to preserve existing behavior. But with `native_scale=True`, values will be treated as they would by other seaborn or matplotlib functions. Element widths will be derived from the minimum distance between two unique values on the categorical axis.
 
-Additionally, while seaborn previously determined the mapping from categorical values to ordinal positions internally, it is now delegated to matplotlib. This should mostly be transparent to the user, but categorical plots (even with `native_scale=False`) will better align with artists added by other seaborn or matplotlib functions in most cases, and matplotlib's interactive machinery will work better.
+Additionally, while seaborn previously determined the mapping from categorical values to ordinal positions internally, this is now delegated to matplotlib. The change should mostly be transparent to the user, but categorical plots (even with `native_scale=False`) will better align with artists added by other seaborn or matplotlib functions in most cases, and matplotlib's interactive machinery will work better.
 
 Changes to color defaults and specification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -35,7 +39,7 @@ Other features, enhancements, and changes to categorical plots
 
 The following updates apply to multiple categorical functions.
 
-- |Feature| All functions now accept a `legend` parameter, which can be a boolean (to suppress the legend) or one of `{"auto", "brief"`, `"full"}` to control the amount of information shown in the legend for a numerical color mapping.
+- |Feature| All functions now accept a `legend` parameter, which can be a boolean (to suppress the legend) or one of `{"auto", "brief", "full"}` to control the amount of information shown in the legend for a numerical color mapping.
 
 - |Feature| All functions now accept a callable `formatter` parameter to control the string representation of the data.
 
@@ -65,7 +69,7 @@ The following updates are function-specific.
 
 - |API| |Enhancement| In :func:`boxenplot`, the boxen are now drawn with separate patch artists in each tail. This may have consequences for code that works with the underlying artists, but it produces a better result for low-alpha / unfilled plots and enables proper area/density scaling.
 
-- |API| |Enhancement| In :func:`barplot`, the `errcolor`` and `errwidth` parameters are now deprecated in favor of a more general `err_kws`` dictionary. The existing parameters will continue to work for two releases.
+- |API| |Enhancement| In :func:`barplot`, the `errcolor` and `errwidth` parameters are now deprecated in favor of a more general `err_kws`` dictionary. The existing parameters will continue to work for two releases.
 
 - |API| In :func:`violinplot`, the `scale` and `scale_hue` parameters have been renamed to `density_norm` and `common_norm` for clarity and to reflect the fact that common normalization is now applied over both hue and faceting variables in :func:`catplot`.
 
@@ -91,10 +95,13 @@ The following updates are function-specific.
 
 - |Enhancement| In :func:`boxplot`, the artists that comprise each box plot are now packaged in a `BoxPlotContainer` for easier post-plotting access.
 
-Other changes
-^^^^^^^^^^^^^
+Support for alternate dataframe libraries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - |Feature| Nearly all functions / objects now use the `dataframe exchange protocol <https://data-apis.org/dataframe-protocol/latest/index.html>`_ to accept `DataFrame` objects from libraries other than `pandas` (e.g. `polars`). Note that seaborn will still convert the data object to pandas internally, but this feature will simplify code for users of other dataframe libraries (:pr:`3369`).
+
+Improved configuration for the objects interface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - |Feature| Added control over the default theme to :class:`objects.Plot` (:pr:`3223`)
 
@@ -102,17 +109,26 @@ Other changes
 
 - |Feature| Added the concept of a "layer legend" in :class:`objects.Plot` via the new `label` parameter in :meth:`objects.Plot.add` (:pr:`3456`).
 
-- |Enhancement| Improved the legend display for relational and categorical functions to better represent the user's additional keyword arguments (:pr:`3467`).
-
 - |Enhancement| In :meth:`objects.Plot.scale`, :meth:`objects.Plot.limit`, and :meth:`objects.Plot.label` the `x` / `y` parameters can be used to set a common scale / limit / label for paired subplots (:pr:`3458`).
 
-- |Enhancement| Updated :func:`load_dataset` to use an approach more compatible with `pyiodide` (:pr:`3234`).
+Other updates
+^^^^^^^^^^^^^
+
+- |Enhancement| Improved the legend display for relational and categorical functions to better represent the user's additional keyword arguments (:pr:`3467`).
 
 - |Enhancement| In :func:`ecdfplot`, `stat="percent"` is now a valid option (:pr:`3336`).
 
-- |Enhancement| Generalized support for performing statistics in the appropriate space based on axes scales; previously support for this was spotty and at best worked only for log scales (:pr:`3440`).
+- |Enhancement| Data values outside the scale transform domain (e.g. non-positive values with a log scale) are now dropped prior to any statistical operations (:pr:`3488`).
 
-- |API| Support for array-typed palettes is now deprecated. This was no previously documented as supported, but it worked by accident in a few places (:pr:`3452`).
+- |Enhancement| In :func:`histplot`, infinite values are now ignored when choosing the default bin range (:pr:`3488`).
+
+- |Enhancement| There is now generalized support for performing statistics in the appropriate space based on axes scales; previously support for this was spotty and at best worked only for log scales (:pr:`3440`).
+
+- |Enhancement| Updated :func:`load_dataset` to use an approach more compatible with `pyiodide` (:pr:`3234`).
+
+- |API| Support for array-typed palettes is now deprecated. This was not previously documented as supported, but it worked by accident in a few places (:pr:`3452`).
+
+- |API| |Fix| In :func:`histplot`, treatment of the `binwidth` parameter has changed such that the actual bin width will be only approximately equal to the requested width when that value does not evenly divide the bin range. This fixes an issue where the largest data value was sometimes dropped due to floating point error (:pr:`3489`).
 
 - |Fix| Fixed :class:`objects.Bar` and :class:`objects.Bars` widths when using a nonlinear scale (:pr:`3217`).
 

--- a/examples/heat_scatter.py
+++ b/examples/heat_scatter.py
@@ -6,7 +6,6 @@ _thumb: .5, .5
 
 """
 import seaborn as sns
-from seaborn._compat import get_legend_handles
 sns.set_theme(style="whitegrid")
 
 # Load the brain networks dataset, select subset, and collapse the multi-index
@@ -38,5 +37,3 @@ g.despine(left=True, bottom=True)
 g.ax.margins(.02)
 for label in g.ax.get_xticklabels():
     label.set_rotation(90)
-for artist in get_legend_handles(g.legend):
-    artist.set_edgecolor(".7")

--- a/examples/horizontal_boxplot.py
+++ b/examples/horizontal_boxplot.py
@@ -17,12 +17,13 @@ ax.set_xscale("log")
 planets = sns.load_dataset("planets")
 
 # Plot the orbital period with horizontal boxes
-sns.boxplot(x="distance", y="method", data=planets,
-            whis=[0, 100], width=.6, palette="vlag")
+sns.boxplot(
+    planets, x="distance", y="method", hue="method",
+    whis=[0, 100], width=.6, palette="vlag"
+)
 
 # Add in points to show each observation
-sns.stripplot(x="distance", y="method", data=planets,
-              size=4, color=".3", linewidth=0)
+sns.stripplot(planets, x="distance", y="method", size=4, color=".3")
 
 # Tweak the visual presentation
 ax.xaxis.grid(True)

--- a/examples/jitter_stripplot.py
+++ b/examples/jitter_stripplot.py
@@ -3,7 +3,6 @@ Conditional means with observations
 ===================================
 
 """
-import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 
@@ -11,7 +10,7 @@ sns.set_theme(style="whitegrid")
 iris = sns.load_dataset("iris")
 
 # "Melt" the dataset to "long-form" or "tidy" representation
-iris = pd.melt(iris, "species", var_name="measurement")
+iris = iris.melt(id_vars="species", var_name="measurement")
 
 # Initialize the figure
 f, ax = plt.subplots()
@@ -20,7 +19,7 @@ sns.despine(bottom=True, left=True)
 # Show each observation with a scatterplot
 sns.stripplot(
     data=iris, x="value", y="measurement", hue="species",
-    dodge=True, alpha=.25, zorder=1, legend=False
+    dodge=True, alpha=.25, zorder=1, legend=False,
 )
 
 # Show the conditional means, aligning each pointplot in the
@@ -28,11 +27,11 @@ sns.stripplot(
 # category (.8 by default) by the number of hue levels
 sns.pointplot(
     data=iris, x="value", y="measurement", hue="species",
-    join=False, dodge=.8 - .8 / 3, palette="dark",
-    markers="d", scale=.75, errorbar=None
+    dodge=.8 - .8 / 3, palette="dark", errorbar=None,
+    markers="d", markersize=4, linestyle="none",
 )
 
 # Improve the legend
 sns.move_legend(
-    ax, loc="lower right", ncol=3, frameon=True, columnspacing=1, handletextpad=0
+    ax, loc="lower right", ncol=3, frameon=True, columnspacing=1, handletextpad=0,
 )

--- a/examples/large_distributions.py
+++ b/examples/large_distributions.py
@@ -9,6 +9,7 @@ sns.set_theme(style="whitegrid")
 diamonds = sns.load_dataset("diamonds")
 clarity_ranking = ["I1", "SI2", "SI1", "VS2", "VS1", "VVS2", "VVS1", "IF"]
 
-sns.boxenplot(x="clarity", y="carat",
-              color="b", order=clarity_ranking,
-              scale="linear", data=diamonds)
+sns.boxenplot(
+    diamonds, x="clarity", y="carat",
+    color="b", order=clarity_ranking, width_method="linear",
+)

--- a/examples/paired_pointplots.py
+++ b/examples/paired_pointplots.py
@@ -15,6 +15,6 @@ g = sns.PairGrid(titanic, y_vars="survived",
                  height=5, aspect=.5)
 
 # Draw a seaborn pointplot onto each Axes
-g.map(sns.pointplot, scale=1.3, errwidth=4, color="xkcd:plum")
+g.map(sns.pointplot, color="xkcd:plum")
 g.set(ylim=(0, 1))
 sns.despine(fig=g.fig, left=True)

--- a/examples/palette_choices.py
+++ b/examples/palette_choices.py
@@ -15,19 +15,19 @@ f, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(7, 5), sharex=True)
 # Generate some sequential data
 x = np.array(list("ABCDEFGHIJ"))
 y1 = np.arange(1, 11)
-sns.barplot(x=x, y=y1, palette="rocket", ax=ax1)
+sns.barplot(x=x, y=y1, hue=x, palette="rocket", ax=ax1)
 ax1.axhline(0, color="k", clip_on=False)
 ax1.set_ylabel("Sequential")
 
 # Center the data to make it diverging
 y2 = y1 - 5.5
-sns.barplot(x=x, y=y2, palette="vlag", ax=ax2)
+sns.barplot(x=x, y=y2, hue=x, palette="vlag", ax=ax2)
 ax2.axhline(0, color="k", clip_on=False)
 ax2.set_ylabel("Diverging")
 
 # Randomly reorder the data to make it qualitative
 y3 = rs.choice(y1, len(y1), replace=False)
-sns.barplot(x=x, y=y3, palette="deep", ax=ax3)
+sns.barplot(x=x, y=y3, hue=x, palette="deep", ax=ax3)
 ax3.axhline(0, color="k", clip_on=False)
 ax3.set_ylabel("Qualitative")
 

--- a/examples/simple_violinplots.py
+++ b/examples/simple_violinplots.py
@@ -1,18 +1,13 @@
 """
-Violinplots with observations
-=============================
+Horizontal, unfilled violinplots
+================================
 
+_thumb: .5, .45
 """
-import numpy as np
 import seaborn as sns
 
 sns.set_theme()
 
-# Create a random dataset across several variables
-rs = np.random.default_rng(0)
-n, p = 40, 8
-d = rs.normal(0, 2, (n, p))
-d += np.log(np.arange(1, p + 1)) * -5 + 10
-
-# Show each distribution with both violins and points
-sns.violinplot(data=d, palette="light:g", inner="points", orient="h")
+seaice = sns.load_dataset("seaice")
+seaice["Decade"] = seaice["Date"].dt.year.round(-1)
+sns.violinplot(seaice, x="Extent", y="Decade", orient="y", fill=False)

--- a/examples/wide_form_violinplot.py
+++ b/examples/wide_form_violinplot.py
@@ -27,7 +27,7 @@ corr_df = corr_df.sort_index().T
 f, ax = plt.subplots(figsize=(11, 6))
 
 # Draw a violinplot with a narrower bandwidth than the default
-sns.violinplot(data=corr_df, bw_adjust=.5, cut=1, linewidth=1)
+sns.violinplot(data=corr_df, bw_adjust=.5, cut=1, linewidth=1, palette="Set3")
 
 # Finalize the figure
 ax.set(ylim=(-.7, 1.05))

--- a/examples/wide_form_violinplot.py
+++ b/examples/wide_form_violinplot.py
@@ -27,7 +27,7 @@ corr_df = corr_df.sort_index().T
 f, ax = plt.subplots(figsize=(11, 6))
 
 # Draw a violinplot with a narrower bandwidth than the default
-sns.violinplot(data=corr_df, palette="Set3", bw_adjust=.5, cut=1, linewidth=1)
+sns.violinplot(data=corr_df, bw_adjust=.5, cut=1, linewidth=1)
 
 # Finalize the figure
 ax.set(ylim=(-.7, 1.05))

--- a/seaborn/_base.py
+++ b/seaborn/_base.py
@@ -1152,9 +1152,9 @@ class VectorPlotter:
                 for ax in ax_list:
                     set_scale = getattr(ax, f"set_{axis}scale")
                     if scale is True:
-                        set_scale("log")
+                        set_scale("log", nonpositive="mask")
                     else:
-                        set_scale("log", base=scale)
+                        set_scale("log", base=scale, nonpositive="mask")
 
         # For categorical y, we want the "first" level to be at the top of the axis
         if self.var_types.get("y", None) == "categorical":

--- a/seaborn/_core/groupby.py
+++ b/seaborn/_core/groupby.py
@@ -93,7 +93,7 @@ class GroupBy:
 
         res = (
             data
-            .groupby(grouper, sort=False, observed=True)
+            .groupby(grouper, sort=False, observed=False)
             .agg(*args, **kwargs)
             .reindex(groups)
             .reset_index()
@@ -113,7 +113,7 @@ class GroupBy:
             return self._reorder_columns(func(data, *args, **kwargs), data)
 
         parts = {}
-        for key, part_df in data.groupby(grouper, sort=False):
+        for key, part_df in data.groupby(grouper, sort=False, observed=False):
             parts[key] = func(part_df, *args, **kwargs)
         stack = []
         for key in groups:

--- a/seaborn/_core/plot.py
+++ b/seaborn/_core/plot.py
@@ -1088,9 +1088,14 @@ class Plotter:
 
     def _resolve_label(self, p: Plot, var: str, auto_label: str | None) -> str:
 
+        if re.match(r"[xy]\d+", var):
+            key = var if var in p._labels else var[0]
+        else:
+            key = var
+
         label: str
-        if var in p._labels:
-            manual_label = p._labels[var]
+        if key in p._labels:
+            manual_label = p._labels[key]
             if callable(manual_label) and auto_label is not None:
                 label = manual_label(auto_label)
             else:

--- a/seaborn/_stats/counting.py
+++ b/seaborn/_stats/counting.py
@@ -120,7 +120,7 @@ class Hist(Stat):
 
     def _define_bin_edges(self, vals, weight, bins, binwidth, binrange, discrete):
         """Inner function that takes bin parameters as arguments."""
-        vals = vals.dropna()
+        vals = vals.replace(-np.inf, np.nan).replace(np.inf, np.nan).dropna()
 
         if binrange is None:
             start, stop = vals.min(), vals.max()

--- a/seaborn/_stats/counting.py
+++ b/seaborn/_stats/counting.py
@@ -66,6 +66,8 @@ class Hist(Stat):
         of bins, or the bin breaks. Passed to :func:`numpy.histogram_bin_edges`.
     binwidth : float
         Width of each bin; overrides `bins` but can be used with `binrange`.
+        Note that if `binwidth` does not evenly divide the bin range, the actual
+        bin width used will be only approximately equal to the parameter value.
     binrange : (min, max)
         Lowest and highest value for bin edges; can be used with either
         `bins` (when a number) or `binwidth`. Defaults to data extremes.
@@ -129,10 +131,9 @@ class Hist(Stat):
 
         if discrete:
             bin_edges = np.arange(start - .5, stop + 1.5)
-        elif binwidth is not None:
-            step = binwidth
-            bin_edges = np.arange(start, stop + step, step)
         else:
+            if binwidth is not None:
+                bins = int(round((stop - start) / binwidth))
             bin_edges = np.histogram_bin_edges(vals, bins, binrange, weight)
 
         # TODO warning or cap on too many bins?

--- a/seaborn/axisgrid.py
+++ b/seaborn/axisgrid.py
@@ -1522,7 +1522,7 @@ class PairGrid(Grid):
         fixed_color = kwargs.pop("color", None)
 
         for var, ax in zip(self.diag_vars, self.diag_axes):
-            hue_grouped = self.data[var].groupby(self.hue_vals)
+            hue_grouped = self.data[var].groupby(self.hue_vals, observed=True)
 
             plot_kwargs = kwargs.copy()
             if str(func.__module__).startswith("seaborn"):
@@ -1629,7 +1629,7 @@ class PairGrid(Grid):
         else:
             axes_vars = [x_var, y_var]
 
-        hue_grouped = self.data.groupby(self.hue_vals)
+        hue_grouped = self.data.groupby(self.hue_vals, observed=True)
         for k, label_k in enumerate(self._hue_order):
 
             kws = kwargs.copy()

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2755,17 +2755,14 @@ def catplot(
         elif x is not None and y is not None:
             raise ValueError("Cannot pass values for both `x` and `y`.")
 
-    if kind == "point" and palette is None and color is None:
-        # Handle special backwards compatibility where pointplot originally
-        # did *not* default to multi-colored unless a palette was specified.
-        color = "C0"
-
     p = Plotter(
         data=data,
         variables=dict(x=x, y=y, hue=hue, row=row, col=col, units=units),
         order=order,
         orient=orient,
-        color=color,
+        # Handle special backwards compatibility where pointplot originally
+        # did *not* default to multi-colored unless a palette was specified.
+        color="C0" if kind == "point" and palette is None and color is None else color,
         legend=legend,
     )
 

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -1184,7 +1184,8 @@ class _CategoricalPlotter(VectorPlotter):
 
             if dodge:
                 hue_idx = self._hue_map.levels.index(sub_vars["hue"])
-                offset = -dodge * (n_hue_levels - 1) / 2 + dodge * hue_idx
+                step_size = dodge / (n_hue_levels - 1)
+                offset = -dodge / 2 + step_size * hue_idx
                 agg_data[self.orient] += offset * self._native_width
 
             self._invert_scale(ax, agg_data)

--- a/seaborn/categorical.py
+++ b/seaborn/categorical.py
@@ -2756,8 +2756,8 @@ def catplot(
             p.variables[var] = f"_{var}_"
 
     # Adapt the plot_data dataframe for use with FacetGrid
-    data = p.plot_data.rename(columns=p.variables)
-    data = data.loc[:, ~data.columns.duplicated()]
+    facet_data = p.plot_data.rename(columns=p.variables)
+    facet_data = facet_data.loc[:, ~facet_data.columns.duplicated()]
 
     col_name = p.variables.get("col", None)
     row_name = p.variables.get("row", None)
@@ -2766,7 +2766,7 @@ def catplot(
         facet_kws = {}
 
     g = FacetGrid(
-        data=data, row=row_name, col=col_name, col_wrap=col_wrap,
+        data=facet_data, row=row_name, col=col_name, col_wrap=col_wrap,
         row_order=row_order, col_order=col_order, sharex=sharex, sharey=sharey,
         legend_out=legend_out, margin_titles=margin_titles,
         height=height, aspect=aspect,
@@ -3073,6 +3073,10 @@ def catplot(
 
     if legend and "hue" in p.variables:
         g.add_legend(title=p.variables.get("hue"), label_order=hue_order)
+
+    if data is not None:
+        # Replace the dataframe on the FacetGrid for any subsequent maps
+        g.data = data
 
     return g
 

--- a/seaborn/distributions.py
+++ b/seaborn/distributions.py
@@ -1608,7 +1608,7 @@ def kdeplot(
             action_taken = "assigning data to `x`."
         msg = textwrap.dedent(f"""\n
         The `vertical` parameter is deprecated; {action_taken}
-        This will become an error in seaborn v0.13.0; please update your code.
+        This will become an error in seaborn v0.14.0; please update your code.
         """)
         warnings.warn(msg, UserWarning, stacklevel=2)
 
@@ -1618,7 +1618,7 @@ def kdeplot(
         msg = textwrap.dedent(f"""\n
         The `bw` parameter is deprecated in favor of `bw_method` and `bw_adjust`.
         Setting `bw_method={bw}`, but please see the docs for the new parameters
-        and update your code. This will become an error in seaborn v0.13.0.
+        and update your code. This will become an error in seaborn v0.14.0.
         """)
         warnings.warn(msg, UserWarning, stacklevel=2)
         bw_method = bw
@@ -1627,7 +1627,7 @@ def kdeplot(
     if kwargs.pop("kernel", None) is not None:
         msg = textwrap.dedent("""\n
         Support for alternate kernels has been removed; using Gaussian kernel.
-        This will become an error in seaborn v0.13.0; please update your code.
+        This will become an error in seaborn v0.14.0; please update your code.
         """)
         warnings.warn(msg, UserWarning, stacklevel=2)
 
@@ -1638,7 +1638,7 @@ def kdeplot(
             thresh = 0
         msg = textwrap.dedent(f"""\n
         `shade_lowest` has been replaced by `thresh`; setting `thresh={thresh}.
-        This will become an error in seaborn v0.13.0; please update your code.
+        This will become an error in seaborn v0.14.0; please update your code.
         """)
         warnings.warn(msg, UserWarning, stacklevel=2)
 
@@ -1994,7 +1994,7 @@ def rugplot(
         data = a
         msg = textwrap.dedent("""\n
         The `a` parameter has been replaced; use `x`, `y`, and/or `data` instead.
-        Please update your code; This will become an error in seaborn v0.13.0.
+        Please update your code; This will become an error in seaborn v0.14.0.
         """)
         warnings.warn(msg, UserWarning, stacklevel=2)
 
@@ -2006,7 +2006,7 @@ def rugplot(
         data = None
         msg = textwrap.dedent(f"""\n
         The `axis` parameter has been deprecated; use the `{axis}` parameter instead.
-        Please update your code; this will become an error in seaborn v0.13.0.
+        Please update your code; this will become an error in seaborn v0.14.0.
         """)
         warnings.warn(msg, UserWarning, stacklevel=2)
 
@@ -2022,7 +2022,7 @@ def rugplot(
             action_taken = "assigning data to `x`."
         msg = textwrap.dedent(f"""\n
         The `vertical` parameter is deprecated; {action_taken}
-        This will become an error in seaborn v0.13.0; please update your code.
+        This will become an error in seaborn v0.14.0; please update your code.
         """)
         warnings.warn(msg, UserWarning, stacklevel=2)
 

--- a/seaborn/relational.py
+++ b/seaborn/relational.py
@@ -14,6 +14,7 @@ from .utils import (
     _default_color,
     _deprecate_ci,
     _get_transform_functions,
+    _normalize_kwargs,
     _scatter_legend_artist,
 )
 from ._statistics import EstimateAggregator
@@ -236,8 +237,9 @@ class _LinePlotter(_RelationalPlotter):
         # gotten from the corresponding matplotlib function, and calling the
         # function will advance the axes property cycle.
 
-        kws.setdefault("markeredgewidth", kws.pop("mew", .75))
-        kws.setdefault("markeredgecolor", kws.pop("mec", "w"))
+        kws = _normalize_kwargs(kws, mpl.lines.Line2D)
+        kws.setdefault("markeredgewidth", 0.75)
+        kws.setdefault("markeredgecolor", "w")
 
         # Set default error kwargs
         err_kws = self.err_kws.copy()
@@ -396,6 +398,8 @@ class _ScatterPlotter(_RelationalPlotter):
         data = self.comp_data.dropna()
         if data.empty:
             return
+
+        kws = _normalize_kwargs(kws, mpl.collections.PathCollection)
 
         # Define the vectors of x and y positions
         empty = np.full(len(data), np.nan)

--- a/seaborn/utils.py
+++ b/seaborn/utils.py
@@ -901,3 +901,44 @@ def _disable_autolayout():
 def _version_predates(lib: ModuleType, version: str) -> bool:
     """Helper function for checking version compatibility."""
     return Version(lib.__version__) < Version(version)
+
+
+def _scatter_legend_artist(**kws):
+
+    kws = _normalize_kwargs(kws, mpl.collections.PathCollection)
+
+    edgecolor = kws.pop("edgecolor", None)
+    rc = mpl.rcParams
+    line_kws = {
+        "linestyle": "",
+        "marker": kws.pop("marker", "o"),
+        "markersize": np.sqrt(kws.pop("s", rc["lines.markersize"] ** 2)),
+        "markerfacecolor": kws.pop("facecolor", kws.get("color")),
+        "markeredgewidth": kws.pop("linewidth", 0),
+        **kws,
+    }
+
+    if edgecolor is not None:
+        if edgecolor == "face":
+            line_kws["markeredgecolor"] = line_kws["markerfacecolor"]
+        else:
+            line_kws["markeredgecolor"] = edgecolor
+
+    return mpl.lines.Line2D([], [], **line_kws)
+
+
+def _get_patch_legend_artist(fill):
+
+    def legend_artist(**kws):
+
+        color = kws.pop("color", None)
+        if color is not None:
+            if fill:
+                kws["facecolor"] = color
+            else:
+                kws["edgecolor"] = color
+                kws["facecolor"] = "none"
+
+        return mpl.patches.Rectangle((0, 0), 0, 0, **kws)
+
+    return legend_artist

--- a/tests/_core/test_plot.py
+++ b/tests/_core/test_plot.py
@@ -1751,9 +1751,14 @@ class TestPairInterface:
 
     def test_labels(self, long_df):
 
-        label = "Z"
-        p = Plot(long_df, y="y").pair(x=["x", "z"]).label(x1=label).plot()
-        ax1 = p._figure.axes[1]
+        label = "zed"
+        p = (
+            Plot(long_df, y="y")
+            .pair(x=["x", "z"])
+            .label(x=str.capitalize, x1=label)
+        )
+        ax0, ax1 = p.plot()._figure.axes
+        assert ax0.get_xlabel() == "X"
         assert ax1.get_xlabel() == label
 
 

--- a/tests/test_axisgrid.py
+++ b/tests/test_axisgrid.py
@@ -14,6 +14,7 @@ from seaborn.palettes import color_palette
 from seaborn.relational import scatterplot
 from seaborn.distributions import histplot, kdeplot, distplot
 from seaborn.categorical import pointplot
+from seaborn.utils import _version_predates
 from seaborn import axisgrid as ag
 from seaborn._testing import (
     assert_plots_equal,
@@ -1423,13 +1424,14 @@ class TestPairGrid:
 
         assert_plots_equal(ax1, ax2, labels=False)
 
+    @pytest.mark.skipif(_version_predates(mpl, "3.7.0"), reason="Matplotlib bug")
     def test_pairplot_markers(self):
 
         vars = ["x", "y", "z"]
         markers = ["o", "X", "s"]
         g = ag.pairplot(self.df, hue="a", vars=vars, markers=markers)
-        m1 = get_legend_handles(g._legend)[0].get_paths()[0]
-        m2 = get_legend_handles(g._legend)[1].get_paths()[0]
+        m1 = get_legend_handles(g._legend)[0].get_marker()
+        m2 = get_legend_handles(g._legend)[1].get_marker()
         assert m1 != m2
 
         with pytest.warns(UserWarning):
@@ -1485,7 +1487,8 @@ class TestPairGrid:
         g.map(scatterplot)
         assert g.axes.shape == (3, 3)
         for ax in g.axes.flat:
-            assert len(ax.collections) == long_df["a"].nunique() + 1
+            pts = ax.collections[0].get_offsets()
+            assert len(pts) == len(long_df)
 
 
 class TestJointGrid:

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -269,7 +269,7 @@ class SharedScatterTests(SharedAxesLevelTests):
         if data_type == "dict":
             wide_df = {k: v.to_numpy() for k, v in wide_df.items()}
 
-        ax = self.func(data=wide_df, orient=orient)
+        ax = self.func(data=wide_df, orient=orient, color="C0")
         _draw_figure(ax.figure)
 
         cat_idx = 0 if orient in "vx" else 1
@@ -914,7 +914,7 @@ class TestBoxPlot(SharedAxesLevelTests, SharedPatchArtistTests):
     def test_wide_data(self, wide_df, orient):
 
         orient = {"h": "y", "v": "x"}[orient]
-        ax = boxplot(wide_df, orient=orient)
+        ax = boxplot(wide_df, orient=orient, color="C0")
         for i, bxp in enumerate(ax.containers):
             col = wide_df.columns[i]
             self.check_box(bxp[i], wide_df[col], orient, i)
@@ -1007,6 +1007,18 @@ class TestBoxPlot(SharedAxesLevelTests, SharedPatchArtistTests):
         ax = boxplot(long_df, x="a", y="y", color=color, saturation=1)
         for box in ax.containers[0].boxes:
             assert same_color(box.get_facecolor(), color)
+
+    def test_wide_data_multicolored(self, wide_df):
+
+        ax = boxplot(wide_df)
+        assert len(ax.containers) == wide_df.shape[1]
+
+    def test_wide_data_single_color(self, wide_df):
+
+        ax = boxplot(wide_df, color="C1", saturation=1)
+        assert len(ax.containers) == 1
+        for box in ax.containers[0].boxes:
+            assert same_color(box.get_facecolor(), "C1")
 
     def test_hue_colors(self, long_df):
 
@@ -1699,7 +1711,7 @@ class TestViolinPlot(SharedAxesLevelTests, SharedPatchArtistTests):
     def test_density_norm_area(self, long_df):
 
         y = long_df["y"].to_numpy()
-        ax = violinplot([y, y * 5])
+        ax = violinplot([y, y * 5], color="C0")
         widths = []
         for poly in ax.collections:
             widths.append(self.violin_width(poly))
@@ -1708,7 +1720,7 @@ class TestViolinPlot(SharedAxesLevelTests, SharedPatchArtistTests):
     def test_density_norm_count(self, long_df):
 
         y = long_df["y"].to_numpy()
-        ax = violinplot([np.repeat(y, 3), y], density_norm="count")
+        ax = violinplot([np.repeat(y, 3), y], density_norm="count", color="C0")
         widths = []
         for poly in ax.collections:
             widths.append(self.violin_width(poly))
@@ -2441,6 +2453,11 @@ class TestPointPlot(SharedAggTests):
         for i, line in enumerate(ax.lines[:2]):
             assert_array_equal(line.get_ydata(), y[i::2])
             assert same_color(line.get_color(), f"C{i}")
+
+    def test_wide_data_is_joined(self, wide_df):
+
+        ax = pointplot(wide_df, errorbar=None)
+        assert len(ax.lines) == 1
 
     def test_xy_native_scale(self):
 

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -3076,6 +3076,14 @@ class TestCatPlot(CategoricalFixture):
         for ax in g.axes.flat:
             assert len(ax.collections) == len(self.df.g.unique())
 
+    def test_facetgrid_data(self, long_df):
+
+        g1 = catplot(data=long_df, x="a", y="y", col="c")
+        assert g1.data is long_df
+
+        g2 = catplot(x=long_df["a"], y=long_df["y"], col=long_df["c"])
+        assert g2.data.equals(long_df[["a", "y", "c"]])
+
     @pytest.mark.parametrize("var", ["col", "row"])
     def test_array_faceter(self, long_df, var):
 

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -673,6 +673,7 @@ class SharedScatterTests(SharedAxesLevelTests):
             dict(data="long", x="x", color="C3"),
             dict(data="long", y="y", hue="a", jitter=False),
             dict(data="long", x="a", y="y", hue="z", edgecolor="w", linewidth=.5),
+            dict(data="long", x="a", y="y", hue="z", edgecolor="auto", linewidth=.5),
             dict(data="long", x="a_cat", y="y", hue="z"),
             dict(data="long", x="y", y="s", hue="c", orient="h", dodge=True),
             dict(data="long", x="s", y="y", hue="c", native_scale=True),
@@ -990,6 +991,11 @@ class TestBoxPlot(SharedAxesLevelTests):
             assert same_color(box.get_edgecolor(), color)
         for flier in bxp.fliers:
             assert same_color(flier.get_markeredgecolor(), color)
+
+    def test_linecolor_gray_warning(self, long_df):
+
+        with pytest.warns(FutureWarning, match="Use \"auto\" to set automatic"):
+            boxplot(long_df, x="y", linecolor="gray")
 
     def test_saturation(self, long_df):
 

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -608,6 +608,14 @@ class SharedScatterTests(SharedAxesLevelTests):
         vals = [float(t.get_text()) for t in ax.legend_.texts]
         assert (vals[1] - vals[0]) == approx(vals[2] - vals[1])
 
+    def test_legend_attributes(self, long_df):
+
+        kws = {"edgecolor": "r", "linewidth": 1}
+        ax = self.func(data=long_df, x="x", y="y", hue="a", **kws)
+        for pt in get_legend_handles(ax.get_legend()):
+            assert same_color(pt.get_markeredgecolor(), kws["edgecolor"])
+            assert pt.get_markeredgewidth() == kws["linewidth"]
+
     def test_legend_disabled(self, long_df):
 
         ax = self.func(data=long_df, x="y", y="a", hue="b", legend=False)
@@ -725,6 +733,33 @@ class SharedAggTests(SharedAxesLevelTests):
             assert label == level
 
 
+class SharedPatchArtistTests:
+
+    @pytest.mark.parametrize("fill", [True, False])
+    def test_legend_fill(self, long_df, fill):
+
+        palette = color_palette()
+        ax = self.func(
+            long_df, x="x", y="y", hue="a",
+            saturation=1, linecolor="k", fill=fill,
+        )
+        for i, patch in enumerate(get_legend_handles(ax.get_legend())):
+            fc = patch.get_facecolor()
+            ec = patch.get_edgecolor()
+            if fill:
+                assert same_color(fc, palette[i])
+                assert same_color(ec, "k")
+            else:
+                assert fc == (0, 0, 0, 0)
+                assert same_color(ec, palette[i])
+
+    def test_legend_attributes(self, long_df):
+
+        ax = self.func(long_df, x="x", y="y", hue="a", linewidth=3)
+        for patch in get_legend_handles(ax.get_legend()):
+            assert patch.get_linewidth() == 3
+
+
 class TestStripPlot(SharedScatterTests):
 
     func = staticmethod(stripplot)
@@ -787,7 +822,7 @@ class TestSwarmPlot(SharedScatterTests):
     func = staticmethod(partial(swarmplot, warn_thresh=1))
 
 
-class TestBoxPlot(SharedAxesLevelTests):
+class TestBoxPlot(SharedAxesLevelTests, SharedPatchArtistTests):
 
     func = staticmethod(boxplot)
 
@@ -1113,7 +1148,7 @@ class TestBoxPlot(SharedAxesLevelTests):
         assert_plots_equal(ax, g.ax)
 
 
-class TestBoxenPlot(SharedAxesLevelTests):
+class TestBoxenPlot(SharedAxesLevelTests, SharedPatchArtistTests):
 
     func = staticmethod(boxenplot)
 
@@ -1410,7 +1445,7 @@ class TestBoxenPlot(SharedAxesLevelTests):
         assert_plots_equal(ax, g.ax)
 
 
-class TestViolinPlot(SharedAxesLevelTests):
+class TestViolinPlot(SharedAxesLevelTests, SharedPatchArtistTests):
 
     func = staticmethod(violinplot)
 
@@ -1687,7 +1722,7 @@ class TestViolinPlot(SharedAxesLevelTests):
 
     def test_common_norm(self, long_df):
 
-        ax = violinplot(long_df, x="a", y="y", hue="c", common_norm=True, legend=False)
+        ax = violinplot(long_df, x="a", y="y", hue="c", common_norm=True)
         widths = []
         for poly in ax.collections:
             widths.append(self.violin_width(poly))
@@ -1891,7 +1926,7 @@ class TestBarPlot(SharedAggTests):
         x, y = ["a", "b", "c"], [1, 2, 3]
         hue = ["x", "x", "y"]
 
-        ax = barplot(x=x, y=y, hue=hue, saturation=1)
+        ax = barplot(x=x, y=y, hue=hue, saturation=1, legend=False)
         for i, bar in enumerate(ax.patches):
             assert bar.get_x() + bar.get_width() / 2 == approx(i)
             assert bar.get_y() == 0
@@ -1916,7 +1951,7 @@ class TestBarPlot(SharedAggTests):
         y = [1, 2, 3, 4]
         hue = ["x", "x", "y", "y"]
 
-        ax = barplot(x=x, y=y, hue=hue, saturation=1)
+        ax = barplot(x=x, y=y, hue=hue, saturation=1, legend=False)
         for i, bar in enumerate(ax.patches):
             sign = 1 if i // 2 else -1
             assert (
@@ -1934,7 +1969,7 @@ class TestBarPlot(SharedAggTests):
         y = [1, 2, 3, 4]
         hue = ["x", "x", "y", "y"]
 
-        ax = barplot(x=x, y=y, hue=hue, gap=.25)
+        ax = barplot(x=x, y=y, hue=hue, gap=.25, legend=False)
         for i, bar in enumerate(ax.patches):
             assert bar.get_width() == approx(0.8 / 2 * .75)
 
@@ -1944,7 +1979,7 @@ class TestBarPlot(SharedAggTests):
         y = [1, 2, 3, 4]
         hue = ["x", "x", "y", "y"]
 
-        ax = barplot(x=x, y=y, hue=hue, saturation=1, dodge=False)
+        ax = barplot(x=x, y=y, hue=hue, saturation=1, dodge=False, legend=False)
         for i, bar in enumerate(ax.patches):
             assert bar.get_x() + bar.get_width() / 2 == approx(i % 2)
             assert bar.get_y() == 0
@@ -1978,7 +2013,7 @@ class TestBarPlot(SharedAggTests):
         y = [1, 2, 3, 4]
         hue = ["x", "x", "y", "y"]
 
-        ax = barplot(x=x, y=y, hue=hue, fill=False)
+        ax = barplot(x=x, y=y, hue=hue, fill=False, legend=False)
         for i, bar in enumerate(ax.patches):
             assert same_color(bar.get_edgecolor(), f"C{i // 2}")
             assert same_color(bar.get_facecolor(), (0, 0, 0, 0))
@@ -2199,6 +2234,26 @@ class TestBarPlot(SharedAggTests):
             assert bar.get_linewidth() == kwargs["linewidth"]
             assert bar.get_facecolor() == kwargs["facecolor"]
             assert bar.get_rasterized() == kwargs["rasterized"]
+
+    def test_legend_attributes(self, long_df):
+
+        palette = color_palette()
+        ax = barplot(
+            long_df, x="a", y="y", hue="c", saturation=1, edgecolor="k", linewidth=3
+        )
+        for i, patch in enumerate(get_legend_handles(ax.get_legend())):
+            assert same_color(patch.get_facecolor(), palette[i])
+            assert same_color(patch.get_edgecolor(), "k")
+            assert patch.get_linewidth() == 3
+
+    def test_legend_unfilled(self, long_df):
+
+        palette = color_palette()
+        ax = barplot(long_df, x="a", y="y", hue="c", fill=False, linewidth=3)
+        for i, patch in enumerate(get_legend_handles(ax.get_legend())):
+            assert patch.get_facecolor() == (0, 0, 0, 0)
+            assert same_color(patch.get_edgecolor(), palette[i])
+            assert patch.get_linewidth() == 3
 
     @pytest.mark.parametrize("fill", [True, False])
     def test_err_kws(self, fill):
@@ -2729,7 +2784,7 @@ class TestCountPlot:
         hue = ["x", "y", "y", "x", "x", "x"]
         counts = [1, 3, 2, 0]
 
-        ax = countplot(x=vals, hue=hue, saturation=1)
+        ax = countplot(x=vals, hue=hue, saturation=1, legend=False)
         for i, bar in enumerate(ax.patches):
             sign = 1 if i // 2 else -1
             assert (
@@ -2869,8 +2924,8 @@ class TestCatPlot(CategoricalFixture):
         assert len(g.ax.lines) == want_elements
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="bar")
-        want_elements = self.g.unique().size * self.h.unique().size
-        assert len(g.ax.patches) == want_elements
+        want_elements = self.g.nunique() * self.h.nunique()
+        assert len(g.ax.patches) == (want_elements + self.h.nunique())
         assert len(g.ax.lines) == want_elements
 
         g = cat.catplot(x="g", data=self.df, kind="count")
@@ -2879,7 +2934,7 @@ class TestCatPlot(CategoricalFixture):
         assert len(g.ax.lines) == 0
 
         g = cat.catplot(x="g", hue="h", data=self.df, kind="count")
-        want_elements = self.g.unique().size * self.h.unique().size
+        want_elements = self.g.nunique() * self.h.nunique() + self.h.nunique()
         assert len(g.ax.patches) == want_elements
         assert len(g.ax.lines) == 0
 
@@ -2892,7 +2947,7 @@ class TestCatPlot(CategoricalFixture):
         assert len(self.get_box_artists(g.ax)) == want_artists
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="box")
-        want_artists = self.g.unique().size * self.h.unique().size
+        want_artists = self.g.nunique() * self.h.nunique()
         assert len(self.get_box_artists(g.ax)) == want_artists
 
         g = cat.catplot(x="g", y="y", data=self.df,
@@ -2902,8 +2957,8 @@ class TestCatPlot(CategoricalFixture):
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df,
                         kind="violin", inner=None)
-        want_elements = self.g.unique().size * self.h.unique().size
-        assert len(g.ax.collections) == want_elements + self.h.unique().size
+        want_elements = self.g.nunique() * self.h.nunique()
+        assert len(g.ax.collections) == want_elements
 
         g = cat.catplot(x="g", y="y", data=self.df, kind="strip")
         want_elements = self.g.unique().size
@@ -2912,7 +2967,7 @@ class TestCatPlot(CategoricalFixture):
             assert same_color(strip.get_facecolors(), "C0")
 
         g = cat.catplot(x="g", y="y", hue="h", data=self.df, kind="strip")
-        want_elements = self.g.unique().size + self.h.unique().size
+        want_elements = self.g.nunique()
         assert len(g.ax.collections) == want_elements
 
     def test_bad_plot_kind_error(self):
@@ -2954,13 +3009,15 @@ class TestCatPlot(CategoricalFixture):
         plt.close("all")
 
         ax = cat.pointplot(x="g", y="y", data=self.df, color="purple")
-        g = cat.catplot(x="g", y="y", data=self.df, color="purple")
+        g = cat.catplot(x="g", y="y", data=self.df, color="purple", kind="point")
         for l1, l2 in zip(ax.lines, g.ax.lines):
             assert l1.get_color() == l2.get_color()
         plt.close("all")
 
         ax = cat.pointplot(x="g", y="y", data=self.df, palette="Set2", hue="h")
-        g = cat.catplot(x="g", y="y", data=self.df, palette="Set2", hue="h")
+        g = cat.catplot(
+            x="g", y="y", data=self.df, palette="Set2", hue="h", kind="point"
+        )
         for l1, l2 in zip(ax.lines, g.ax.lines):
             assert l1.get_color() == l2.get_color()
         plt.close("all")

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1745,7 +1745,7 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
     def test_log_scale_explicit(self, rng):
 
         x = rng.lognormal(0, 2, 1000)
-        ax = histplot(x, log_scale=True, binwidth=1)
+        ax = histplot(x, log_scale=True, binrange=(-3, 3), binwidth=1)
 
         bar_widths = [b.get_width() for b in ax.patches]
         steps = np.divide(bar_widths[1:], bar_widths[:-1])
@@ -1757,7 +1757,7 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
 
         f, ax = plt.subplots()
         ax.set_xscale("log")
-        histplot(x, binwidth=1, ax=ax)
+        histplot(x, binrange=(-3, 3), binwidth=1, ax=ax)
 
         bar_widths = [b.get_width() for b in ax.patches]
         steps = np.divide(bar_widths[1:], bar_widths[:-1])

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1445,6 +1445,13 @@ class TestHistPlotUnivariate(SharedAxesLevelTests):
             assert_array_almost_equal(start, wide_df[col].min())
             assert_array_almost_equal(stop, wide_df[col].max())
 
+    def test_range_with_inf(self, rng):
+
+        x = rng.normal(0, 1, 20)
+        ax = histplot([-np.inf, *x])
+        leftmost_edge = min(p.get_x() for p in ax.patches)
+        assert leftmost_edge == x.min()
+
     def test_weights_with_missing(self, null_df):
 
         ax = histplot(null_df, x="x", weights="s", bins=5)

--- a/tests/test_relational.py
+++ b/tests/test_relational.py
@@ -1732,6 +1732,12 @@ class TestScatterPlotter(SharedAxesLevelTests, Helpers):
             warnings.simplefilter("error")
             scatterplot(data=long_df, x="x", y="y", marker="+")
 
+    def test_short_form_kwargs(self, long_df):
+
+        ax = scatterplot(data=long_df, x="x", y="y", ec="g")
+        pts = ax.collections[0]
+        assert same_color(pts.get_edgecolors().squeeze(), "g")
+
     def test_scatterplot_vs_relplot(self, long_df, long_semantics):
 
         ax = scatterplot(data=long_df, **long_semantics)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -437,7 +437,7 @@ def test_move_legend_with_labels(long_df):
     ax = scatterplot(long_df, x="x", y="y", hue="a", hue_order=order)
 
     handles_before = get_legend_handles(ax.get_legend())
-    colors_before = [tuple(h.get_facecolor().squeeze()) for h in handles_before]
+    colors_before = [h.get_markerfacecolor() for h in handles_before]
     utils.move_legend(ax, "best", labels=labels)
     _draw_figure(ax.figure)
 
@@ -445,7 +445,7 @@ def test_move_legend_with_labels(long_df):
     assert texts == labels
 
     handles_after = get_legend_handles(ax.get_legend())
-    colors_after = [tuple(h.get_facecolor().squeeze()) for h in handles_after]
+    colors_after = [h.get_markerfacecolor() for h in handles_after]
     assert colors_before == colors_after
 
     with pytest.raises(ValueError, match="Length of new labels"):


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `74a8301..782b71e`
**Files Changed:** 26 (23 programming files)
**Programming Ratio:** 88.5%

**Commits included:**
- Address a couple of warnings that turned up only in the docs (#3500)
- Fix catplot with kind='point' to avoid color warning (#3499)
- Postpone some removals of deprecated features (#3497)
- Update release notes
- Restore implicit hue for wide categorical data (#3496)
- Fix data attached to catplot FacetGrid (#3494)
- Fix pointplot dodge calculation (#3493)
- Update examples that use deprecated/changed parameters in gallery (#3492)
- Treat binwidth as approximate to avoid dropping outermost datapoints (#3489)
- Mask nonpositive values with log_scale and ignore inf data in histogram range (#3488)
... and 5 more commits